### PR TITLE
add required upload flag for newer versions of libcurl.  Without this…

### DIFF
--- a/src/SMTPClient.jl
+++ b/src/SMTPClient.jl
@@ -170,6 +170,7 @@ function setup_easy_handle(url, options::SendOptions)
 
     @ce_curl curl_easy_setopt CURLOPT_URL url
     @ce_curl curl_easy_setopt CURLOPT_WRITEFUNCTION c_write_cb
+    @ce_curl curl_easy_setopt CURLOPT_UPLOAD 1
     @ce_curl curl_easy_setopt CURLOPT_WRITEDATA p_ctxt
 
     if options.isSSL


### PR DESCRIPTION
… flag, the library fails to send via SSL

see: http://stackoverflow.com/questions/23449082/unable-to-send-emails-using-libcurl
