### PR TITLE
Whitespace and deprecation fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.4
 LibCURL


### PR DESCRIPTION
This fixes whitespace and 0.4 deprecations. I didn't bother with Compat, because 0.4 is stable now and people can always use the older version. Any objections?
