### PR TITLE
Enclose filename in double quotes

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -22,7 +22,7 @@ function encode_attachment(filename::String)
 
     encoded_str = 
         "Content-Disposition: $content_disposition;\r\n" *
-        "    filename=$(basename(filename))\r\n" *
+        "    filename=\"$(basename(filename))\"\r\n" *
         "Content-Type: $content_type;\r\n" *
         "    name=\"$(basename(filename))\"\r\n" *
         "Content-ID: <$(basename(filename))>\r\n" *


### PR DESCRIPTION
Filenames with special characters like parentheses or spaces need to be enclosed in double quotes.
It's safest to always enclose filenames in double quotes.