### PR TITLE
HTML encode non-ASCII characters

### DIFF
--- a/src/user.jl
+++ b/src/user.jl
@@ -67,6 +67,11 @@ get_mime_msg(message::String, ::Val{:usascii}) =
 get_mime_msg(message::String) = get_mime_msg(message, Val(:utf8))
 
 function get_mime_msg(message::String, ::Val{:html})
+    message_bytes = collect(message)
+    if !isnothing(findfirst(>(Char(0x7f)), message_bytes))
+        # Message contains non-ASCII characters (non 7-bit safe) that we need to HTML encode
+        message = join(map(c -> c > Char(0x7f) ? "&#$(codepoint(c));" : c, message_bytes), "")
+    end
     msg = 
         "Content-Type: text/html;\r\n" *
         "Content-Transfer-Encoding: 7bit;\r\n\r\n" *

--- a/test/send.jl
+++ b/test/send.jl
@@ -129,7 +129,7 @@ end
 
     let  # send using get_body with HTML string encoded message
       message = HTML(
-        """<h2>An important link to look at!</h2>
+        """<h2>An important link to look at! ©</h2>
         Here's an <a href="https://github.com/aviks/SMTPClient.jl">important link</a>\r\n"""
       )
 
@@ -148,7 +148,7 @@ end
         @test occursin("Content-Transfer-Encoding: 7bit;", s)
         @test occursin("<html>", s)
         @test occursin("<body>", s)
-        @test occursin("<h2>An important link to look at!</h2>", s)
+        @test occursin("<h2>An important link to look at! &#169;</h2>", s)
         @test occursin(
             "<a href=\"https://github.com/aviks/SMTPClient.jl\">important link</a>",
             s


### PR DESCRIPTION
Since we set `Content-Transfer-Encoding` to `7bit` for HTML messages, we need to ensure that the passed in HTML is 7 bit safe. This is done by replacing any character with higher bits with their HTML entity encoding.

There may be more efficient ways to achieve this, but I've found that working on the string character by character results in the fewest allocations.